### PR TITLE
Set numeric parser to Number

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -1,8 +1,10 @@
 import { Kysely, PostgresDialect } from 'kysely';
-import { Pool } from 'pg';
+import { Pool, types } from 'pg';
 
 import { Database } from './tables.js';
 import config from '../config.js';
+
+types.setTypeParser(types.builtins.NUMERIC, Number);
 
 const dialect = new PostgresDialect({
   pool: new Pool({


### PR DESCRIPTION
This fixes a bug where locations (that have the `numeric` type) are returned as strings