### PR TITLE
Fix prev exp

### DIFF
--- a/server/src/api/routes/organization/attendance.test.ts
+++ b/server/src/api/routes/organization/attendance.test.ts
@@ -104,6 +104,80 @@ describe('Organization attendance endpoints', () => {
     expect(fetch2.body.enrollments[0].dates?.[0].attended).toBe(true);
   });
 
+  test('PATCH /organization/posting/:id/enrollment-dates/:enrollmentDateId/attendance marks full-commitment enrollment as attended only when all days are attended', async () => {
+    const org = await createOrganizationAccount(transaction, { email: 'org-full@example.com' });
+    const volunteer = await createVolunteerAccount(transaction, { email: 'vol-full@example.com' });
+
+    const posting = await createOrganizationPosting(transaction, {
+      organizationId: org.organization.id,
+      overrides: {
+        allows_partial_attendance: false,
+        start_date: new Date('2026-01-01'),
+        end_date: new Date('2026-01-02'),
+      },
+    });
+
+    const enrollment = await transaction
+      .insertInto('enrollment')
+      .values({
+        volunteer_id: volunteer.volunteer.id,
+        posting_id: posting.id,
+        attended: false,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    const firstDay = await transaction
+      .insertInto('enrollment_date')
+      .values({
+        enrollment_id: enrollment.id,
+        posting_id: posting.id,
+        date: new Date('2026-01-01'),
+        attended: false,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    const secondDay = await transaction
+      .insertInto('enrollment_date')
+      .values({
+        enrollment_id: enrollment.id,
+        posting_id: posting.id,
+        date: new Date('2026-01-02'),
+        attended: false,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    await server
+      .patch(`/organization/posting/${posting.id}/enrollment-dates/${firstDay.id}/attendance`)
+      .set('Authorization', `Bearer ${org.token}`)
+      .send({ attended: true })
+      .expect(200);
+
+    const intermediateEnrollment = await transaction
+      .selectFrom('enrollment')
+      .select(['attended'])
+      .where('id', '=', enrollment.id)
+      .executeTakeFirstOrThrow();
+
+    expect(intermediateEnrollment.attended).toBe(false);
+
+    await server
+      .patch(`/organization/posting/${posting.id}/enrollment-dates/${secondDay.id}/attendance`)
+      .set('Authorization', `Bearer ${org.token}`)
+      .send({ attended: true })
+      .expect(200);
+
+    const updatedEnrollment = await transaction
+      .selectFrom('enrollment')
+      .select(['attended'])
+      .where('id', '=', enrollment.id)
+      .executeTakeFirstOrThrow();
+
+    expect(updatedEnrollment.attended).toBe(true);
+  });
+
   test('PATCH /organization/posting/:id/attendance updates all enrollment attendance and recomputes volunteer vectors', async () => {
     const org = await createOrganizationAccount(transaction, { email: 'org-b@example.com' });
     const volunteerOne = await createVolunteerAccount(transaction, { email: 'vol-b1@example.com' });

--- a/server/src/api/routes/organization/attendance.test.ts
+++ b/server/src/api/routes/organization/attendance.test.ts
@@ -104,7 +104,7 @@ describe('Organization attendance endpoints', () => {
     expect(fetch2.body.enrollments[0].dates?.[0].attended).toBe(true);
   });
 
-  test('PATCH /organization/posting/:id/enrollment-dates/:enrollmentDateId/attendance marks full-commitment enrollment as attended only when all days are attended', async () => {
+  test('PATCH /organization/posting/:id/enrollment-dates/:enrollmentDateId/attendance marks an enrollment attended when at least one date is attended', async () => {
     const org = await createOrganizationAccount(transaction, { email: 'org-full@example.com' });
     const volunteer = await createVolunteerAccount(transaction, { email: 'vol-full@example.com' });
 
@@ -155,13 +155,13 @@ describe('Organization attendance endpoints', () => {
       .send({ attended: true })
       .expect(200);
 
-    const intermediateEnrollment = await transaction
+    const firstDayEnrollment = await transaction
       .selectFrom('enrollment')
       .select(['attended'])
       .where('id', '=', enrollment.id)
       .executeTakeFirstOrThrow();
 
-    expect(intermediateEnrollment.attended).toBe(false);
+    expect(firstDayEnrollment.attended).toBe(true);
 
     await server
       .patch(`/organization/posting/${posting.id}/enrollment-dates/${secondDay.id}/attendance`)

--- a/server/src/api/routes/organization/attendance.ts
+++ b/server/src/api/routes/organization/attendance.ts
@@ -182,16 +182,40 @@ function createAttendanceRouter(db: Kysely<Database>) {
       .where('id', '=', enrollmentDateId)
       .execute();
 
-    if (body.attended) {
-      const enrollment = await db
-        .selectFrom('enrollment')
-        .select(['id', 'volunteer_id'])
-        .where('id', '=', dateRecord.enrollment_id)
-        .executeTakeFirst();
+    const enrollment = await db
+      .selectFrom('enrollment')
+      .select(['id', 'volunteer_id'])
+      .where('id', '=', dateRecord.enrollment_id)
+      .executeTakeFirst();
 
-      if (enrollment) {
-        await recomputeVolunteerExperienceVector(enrollment.volunteer_id, db);
-      }
+    if (!enrollment) {
+      res.status(500);
+      throw new Error('Enrollment record is missing');
+    }
+
+    const enrollmentDates = await db
+      .selectFrom('enrollment_date')
+      .select(['attended'])
+      .where('enrollment_id', '=', enrollment.id)
+      .execute();
+
+    const updatedEnrollmentAttended = enrollmentDates.length > 0 && enrollmentDates.every(row => row.attended);
+
+    const currentEnrollment = await db
+      .selectFrom('enrollment')
+      .select(['attended'])
+      .where('id', '=', enrollment.id)
+      .executeTakeFirst();
+
+    if (currentEnrollment && currentEnrollment.attended !== updatedEnrollmentAttended) {
+      await db
+        .updateTable('enrollment')
+        .set({ attended: updatedEnrollmentAttended })
+        .where('id', '=', enrollment.id)
+        .execute();
+
+      await recomputeVolunteerExperienceVector(enrollment.volunteer_id, db);
+      await recomputePostingVectorsForVolunteerEnrollments(enrollment.volunteer_id, db);
     }
 
     res.json({});

--- a/server/src/api/routes/organization/attendance.ts
+++ b/server/src/api/routes/organization/attendance.ts
@@ -199,7 +199,7 @@ function createAttendanceRouter(db: Kysely<Database>) {
       .where('enrollment_id', '=', enrollment.id)
       .execute();
 
-    const updatedEnrollmentAttended = enrollmentDates.length > 0 && enrollmentDates.every(row => row.attended);
+    const updatedEnrollmentAttended = enrollmentDates.length > 0 && enrollmentDates.some(row => row.attended);
 
     const currentEnrollment = await db
       .selectFrom('enrollment')

--- a/server/src/api/routes/public.test.ts
+++ b/server/src/api/routes/public.test.ts
@@ -271,7 +271,7 @@ describe('POST /public/certificate/verify', () => {
     const enrollmentCreatedAt = new Date(issuedAtDate);
     enrollmentCreatedAt.setMinutes(enrollmentCreatedAt.getMinutes() - 2);
 
-    await transaction
+    const enrollments = await transaction
       .insertInto('enrollment')
       .values([
         {
@@ -285,6 +285,25 @@ describe('POST /public/certificate/verify', () => {
           posting_id: postingTwo.id,
           attended: true,
           created_at: enrollmentCreatedAt,
+        },
+      ])
+      .returningAll()
+      .execute();
+
+    await transaction
+      .insertInto('enrollment_date')
+      .values([
+        {
+          enrollment_id: enrollments[0]!.id,
+          posting_id: postingOne.id,
+          date: new Date('2026-02-01T00:00:00.000Z'),
+          attended: true,
+        },
+        {
+          enrollment_id: enrollments[1]!.id,
+          posting_id: postingTwo.id,
+          date: new Date('2026-02-03T00:00:00.000Z'),
+          attended: true,
         },
       ])
       .execute();

--- a/server/src/api/routes/volunteer/index.test.ts
+++ b/server/src/api/routes/volunteer/index.test.ts
@@ -692,13 +692,24 @@ describe('GET /volunteer/certificate', () => {
       .returning(['id'])
       .executeTakeFirstOrThrow();
 
-    await transaction
+    const enrollment = await transaction
       .insertInto('enrollment')
       .values({
         volunteer_id: volunteer.id,
         posting_id: posting.id,
         attended: true,
         created_at: new Date('2026-02-02T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    await transaction
+      .insertInto('enrollment_date')
+      .values({
+        enrollment_id: enrollment.id,
+        posting_id: posting.id,
+        date: new Date('2026-02-01T00:00:00.000Z'),
+        attended: true,
       })
       .execute();
 
@@ -955,7 +966,7 @@ describe('GET /volunteer/certificate', () => {
     const disabledPosting = await createPostingForOrg(disabledOrg.id, 'Disabled Org Posting');
     const deletedPosting = await createPostingForOrg(deletedOrg.id, 'Deleted Org Posting');
 
-    await transaction
+    const enrollments = await transaction
       .insertInto('enrollment')
       .values([
         {
@@ -975,6 +986,31 @@ describe('GET /volunteer/certificate', () => {
           posting_id: deletedPosting.id,
           attended: true,
           created_at: new Date('2026-02-02T00:00:00.000Z'),
+        },
+      ])
+      .returningAll()
+      .execute();
+
+    await transaction
+      .insertInto('enrollment_date')
+      .values([
+        {
+          enrollment_id: enrollments[0]!.id,
+          posting_id: activePosting.id,
+          date: new Date('2026-02-01T00:00:00.000Z'),
+          attended: true,
+        },
+        {
+          enrollment_id: enrollments[1]!.id,
+          posting_id: disabledPosting.id,
+          date: new Date('2026-02-01T00:00:00.000Z'),
+          attended: true,
+        },
+        {
+          enrollment_id: enrollments[2]!.id,
+          posting_id: deletedPosting.id,
+          date: new Date('2026-02-01T00:00:00.000Z'),
+          attended: true,
         },
       ])
       .execute();
@@ -1103,7 +1139,7 @@ describe('GET /volunteer/certificate', () => {
       .returning(['id'])
       .executeTakeFirstOrThrow();
 
-    await transaction
+    const enrollments = await transaction
       .insertInto('enrollment')
       .values([
         {
@@ -1117,6 +1153,25 @@ describe('GET /volunteer/certificate', () => {
           posting_id: disabledPosting.id,
           attended: true,
           created_at: new Date('2026-03-03T00:00:00.000Z'),
+        },
+      ])
+      .returningAll()
+      .execute();
+
+    await transaction
+      .insertInto('enrollment_date')
+      .values([
+        {
+          enrollment_id: enrollments[0]!.id,
+          posting_id: enabledPosting.id,
+          date: new Date('2026-03-01T00:00:00.000Z'),
+          attended: true,
+        },
+        {
+          enrollment_id: enrollments[1]!.id,
+          posting_id: disabledPosting.id,
+          date: new Date('2026-03-02T00:00:00.000Z'),
+          attended: true,
         },
       ])
       .execute();

--- a/server/src/api/routes/volunteer/index.test.ts
+++ b/server/src/api/routes/volunteer/index.test.ts
@@ -761,6 +761,113 @@ describe('GET /volunteer/certificate', () => {
     });
   });
 
+  test('counts only attended days for partial attendance postings on the volunteer certificate', async () => {
+    const { volunteer, token } = await createVolunteerAccount(transaction, { email: 'certificate-partial@example.com' });
+    const { organization } = await createOrganizationAccount(transaction, { email: 'certificate-partial-org@example.com' });
+
+    const certificateInfo = await transaction
+      .insertInto('organization_certificate_info')
+      .values({
+        certificate_feature_enabled: true,
+        hours_threshold: 3,
+        signatory_name: 'Org Signatory',
+        signatory_position: 'Director',
+        signature_path: 'uploads/org-signature.png',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    await transaction
+      .updateTable('organization_account')
+      .set({ certificate_info_id: certificateInfo.id })
+      .where('id', '=', organization.id)
+      .execute();
+
+    const posting = await transaction
+      .insertInto('organization_posting')
+      .values({
+        organization_id: organization.id,
+        title: 'Partial Shift',
+        description: 'Partial attendance event',
+        latitude: 33.9,
+        longitude: 35.5,
+        max_volunteers: 10,
+        start_date: new Date('2026-03-01T00:00:00.000Z'),
+        start_time: '09:00:00',
+        end_date: new Date('2026-03-03T00:00:00.000Z'),
+        end_time: '13:00:00',
+        minimum_age: 18,
+        automatic_acceptance: true,
+        is_closed: false,
+        allows_partial_attendance: true,
+        location_name: 'Beirut',
+        crisis_id: null,
+        created_at: new Date('2026-02-01T00:00:00.000Z'),
+        updated_at: new Date('2026-02-01T00:00:00.000Z'),
+      })
+      .returning(['id'])
+      .executeTakeFirstOrThrow();
+
+    const enrollment = await transaction
+      .insertInto('enrollment')
+      .values({
+        volunteer_id: volunteer.id,
+        posting_id: posting.id,
+        attended: true,
+        created_at: new Date('2026-03-02T00:00:00.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    await transaction
+      .insertInto('enrollment_date')
+      .values([
+        {
+          enrollment_id: enrollment.id,
+          posting_id: posting.id,
+          date: new Date('2026-03-01T00:00:00.000Z'),
+          attended: true,
+        },
+        {
+          enrollment_id: enrollment.id,
+          posting_id: posting.id,
+          date: new Date('2026-03-02T00:00:00.000Z'),
+          attended: false,
+        },
+        {
+          enrollment_id: enrollment.id,
+          posting_id: posting.id,
+          date: new Date('2026-03-03T00:00:00.000Z'),
+          attended: false,
+        },
+      ])
+      .execute();
+
+    await transaction
+      .insertInto('platform_certificate_settings')
+      .values({
+        signatory_name: 'Platform Lead',
+        signatory_position: 'Coordinator',
+        signature_path: 'uploads/platform.png',
+        signature_uploaded_by_admin_id: null,
+        created_at: new Date('2026-02-02T00:00:00.000Z'),
+        updated_at: new Date('2026-02-02T00:00:00.000Z'),
+      })
+      .execute();
+
+    const response = await server
+      .get('/volunteer/certificate')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200);
+
+    expect(response.body.total_hours).toBe(4);
+    expect(response.body.organizations).toHaveLength(1);
+    expect(response.body.organizations[0]).toMatchObject({
+      id: organization.id,
+      hours: 4,
+    });
+  });
+
   test('returns empty organizations and null platform certificate when no certificate data exists', async () => {
     const { volunteer, token } = await createVolunteerAccount(transaction, { email: 'certificate-empty@example.com' });
 

--- a/server/src/api/routes/volunteer/index.ts
+++ b/server/src/api/routes/volunteer/index.ts
@@ -436,8 +436,8 @@ function createVolunteerRouter(db: Kysely<Database>) {
     const hoursPerAttendedDateExpr = sql<number>`GREATEST(
       0,
       EXTRACT(EPOCH FROM (
-        (organization_posting.end_date + organization_posting.end_time)
-        - (organization_posting.start_date + organization_posting.start_time)
+        (enrollment_date.date + organization_posting.end_time)
+        - (enrollment_date.date + organization_posting.start_time)
       )) / 3600.0
     )`;
 
@@ -543,8 +543,8 @@ function createVolunteerRouter(db: Kysely<Database>) {
     const hoursPerAttendedDateExpr = sql<number>`GREATEST(
       0,
       EXTRACT(EPOCH FROM (
-        (organization_posting.end_date + organization_posting.end_time)
-        - (organization_posting.start_date + organization_posting.start_time)
+        (enrollment_date.date + organization_posting.end_time)
+        - (enrollment_date.date + organization_posting.start_time)
       )) / 3600.0
     )`;
 

--- a/server/src/api/routes/volunteer/index.ts
+++ b/server/src/api/routes/volunteer/index.ts
@@ -433,7 +433,7 @@ function createVolunteerRouter(db: Kysely<Database>) {
       .where('is_disabled', '=', false)
       .executeTakeFirstOrThrow();
 
-    const hoursPerPostingExpr = sql<number>`GREATEST(
+    const hoursPerAttendedDateExpr = sql<number>`GREATEST(
       0,
       EXTRACT(EPOCH FROM (
         (organization_posting.end_date + organization_posting.end_time)
@@ -442,16 +442,18 @@ function createVolunteerRouter(db: Kysely<Database>) {
     )`;
 
     const totalHoursRow = await db
-      .selectFrom('enrollment')
+      .selectFrom('enrollment_date')
+      .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
       .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
       .innerJoin('organization_account', 'organization_account.id', 'organization_posting.organization_id')
-      .select(sql<number>`COALESCE(SUM(${hoursPerPostingExpr}), 0)`.as('total_hours'))
+      .select(sql<number>`COALESCE(SUM(${hoursPerAttendedDateExpr}), 0)`.as('total_hours'))
       .where('enrollment.volunteer_id', '=', volunteerId)
-      .where('enrollment.attended', '=', true)
+      .where('enrollment_date.attended', '=', true)
       .executeTakeFirstOrThrow();
 
     const organizations = await db
-      .selectFrom('enrollment')
+      .selectFrom('enrollment_date')
+      .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
       .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
       .innerJoin('organization_account', 'organization_account.id', 'organization_posting.organization_id')
       .leftJoin(
@@ -468,10 +470,10 @@ function createVolunteerRouter(db: Kysely<Database>) {
         'organization_certificate_info.signatory_name',
         'organization_certificate_info.signatory_position',
         'organization_certificate_info.signature_path',
-        sql<number>`SUM(${hoursPerPostingExpr})`.as('hours'),
+        sql<number>`COALESCE(SUM(${hoursPerAttendedDateExpr}), 0)`.as('hours'),
       ])
       .where('enrollment.volunteer_id', '=', volunteerId)
-      .where('enrollment.attended', '=', true)
+      .where('enrollment_date.attended', '=', true)
       .groupBy([
         'organization_account.id',
         'organization_account.name',
@@ -538,7 +540,7 @@ function createVolunteerRouter(db: Kysely<Database>) {
     const issuedAt = new Date();
     const selectedOrgIds = [...body.org_ids].sort((left, right) => left - right);
 
-    const hoursPerPostingExpr = sql<number>`GREATEST(
+    const hoursPerAttendedDateExpr = sql<number>`GREATEST(
       0,
       EXTRACT(EPOCH FROM (
         (organization_posting.end_date + organization_posting.end_time)
@@ -547,14 +549,15 @@ function createVolunteerRouter(db: Kysely<Database>) {
     )`;
 
     const rows = await db
-      .selectFrom('enrollment')
+      .selectFrom('enrollment_date')
+      .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
       .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
       .select([
         'organization_posting.organization_id as organization_id',
-        sql<number>`COALESCE(SUM(${hoursPerPostingExpr}), 0)`.as('hours'),
+        sql<number>`COALESCE(SUM(${hoursPerAttendedDateExpr}), 0)`.as('hours'),
       ])
       .where('enrollment.volunteer_id', '=', volunteerId)
-      .where('enrollment.attended', '=', true)
+      .where('enrollment_date.attended', '=', true)
       .where('enrollment.created_at', '<=', issuedAt)
       .groupBy('organization_posting.organization_id')
       .execute();

--- a/server/src/services/certificates/verification.ts
+++ b/server/src/services/certificates/verification.ts
@@ -20,23 +20,24 @@ const roundHours = (value: number) => Number(value.toFixed(HOURS_DECIMAL_PLACES)
 const isSameHours = (left: number, right: number) => Math.abs(left - right) <= HOURS_EPSILON;
 
 const getVolunteerHoursSnapshot = async (db: Kysely<Database>, volunteerId: number, issuedAt: Date): Promise<VolunteerHoursSnapshot> => {
-  const hoursPerPostingExpression = sql<number>`GREATEST(
+  const hoursPerAttendedDateExpression = sql<number>`GREATEST(
     0,
     EXTRACT(EPOCH FROM (
-      (organization_posting.end_date + organization_posting.end_time)
-      - (organization_posting.start_date + organization_posting.start_time)
+      (enrollment_date.date + organization_posting.end_time)
+      - (enrollment_date.date + organization_posting.start_time)
     )) / 3600.0
   )`;
 
   const rows = await db
-    .selectFrom('enrollment')
+    .selectFrom('enrollment_date')
+    .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
     .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
     .select([
       'organization_posting.organization_id as organization_id',
-      sql<number>`COALESCE(SUM(${hoursPerPostingExpression}), 0)`.as('hours'),
+      sql<number>`COALESCE(SUM(${hoursPerAttendedDateExpression}), 0)`.as('hours'),
     ])
     .where('enrollment.volunteer_id', '=', volunteerId)
-    .where('enrollment.attended', '=', true)
+    .where('enrollment_date.attended', '=', true)
     // Historical attendance timestamps are not fully modeled in schema.
     // We use enrollment.created_at as the strongest available "known by issued_at" bound.
     .where('enrollment.created_at', '<=', issuedAt)

--- a/server/src/services/volunteer/index.ts
+++ b/server/src/services/volunteer/index.ts
@@ -101,12 +101,12 @@ export const getVolunteerProfile = async (volunteerId: number): Promise<Voluntee
     .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
     .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
     .select(sql<number>`COALESCE(SUM(GREATEST(
-      0,
-      EXTRACT(EPOCH FROM (
-        (organization_posting.end_date + organization_posting.end_time)
-        - (organization_posting.start_date + organization_posting.start_time)
-      )) / 3600.0
-    )), 0)`.as('total_hours'))
+    0,
+    EXTRACT(EPOCH FROM (
+      (enrollment_date.date + organization_posting.end_time)
+      - (enrollment_date.date + organization_posting.start_time)
+    )) / 3600.0
+  )), 0)`.as('total_hours'))
     .where('enrollment.volunteer_id', '=', volunteerId)
     .where('enrollment_date.attended', '=', true)
     .executeTakeFirstOrThrow();

--- a/server/src/services/volunteer/index.ts
+++ b/server/src/services/volunteer/index.ts
@@ -101,12 +101,12 @@ export const getVolunteerProfile = async (volunteerId: number): Promise<Voluntee
     .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
     .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
     .select(sql<number>`COALESCE(SUM(GREATEST(
-    0,
-    EXTRACT(EPOCH FROM (
-      (enrollment_date.date + organization_posting.end_time)
-      - (enrollment_date.date + organization_posting.start_time)
-    )) / 3600.0
-  )), 0)`.as('total_hours'))
+  0,
+  EXTRACT(EPOCH FROM (
+    (enrollment_date.date + organization_posting.end_time)
+    - (enrollment_date.date + organization_posting.start_time)
+  )) / 3600.0
+)), 0)`.as('total_hours'))
     .where('enrollment.volunteer_id', '=', volunteerId)
     .where('enrollment_date.attended', '=', true)
     .executeTakeFirstOrThrow();

--- a/server/src/services/volunteer/index.ts
+++ b/server/src/services/volunteer/index.ts
@@ -38,27 +38,6 @@ export type VolunteerProfileData = {
   completed_experiences: VolunteerCompletedExperience[];
 };
 
-const combineDateTimeToDate = (date: Date, time: string) => {
-  const [hoursRaw, minutesRaw = '0', secondsRaw = '0'] = time.split(':');
-  const hours = Number(hoursRaw);
-  const minutes = Number(minutesRaw);
-  const seconds = Number(secondsRaw);
-
-  if (Number.isNaN(hours) || Number.isNaN(minutes) || Number.isNaN(seconds)) {
-    return new Date(Number.NaN);
-  }
-
-  return new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-    hours,
-    minutes,
-    seconds,
-    0,
-  );
-};
-
 export const getVolunteerProfile = async (volunteerId: number): Promise<VolunteerProfileData> => {
   const [volunteer, volunteerSkills, completedExperiences, usedPostingSkills] = await Promise.all([
     database
@@ -117,20 +96,22 @@ export const getVolunteerProfile = async (volunteerId: number): Promise<Voluntee
       .execute(),
   ]);
 
-  const totalHoursCompletedRaw = completedExperiences.reduce((totalHours, experience) => {
-    if (!experience.end_date || !experience.end_time) return totalHours;
+  const totalHoursRow = await database
+    .selectFrom('enrollment_date')
+    .innerJoin('enrollment', 'enrollment.id', 'enrollment_date.enrollment_id')
+    .innerJoin('organization_posting', 'organization_posting.id', 'enrollment.posting_id')
+    .select(sql<number>`COALESCE(SUM(GREATEST(
+      0,
+      EXTRACT(EPOCH FROM (
+        (organization_posting.end_date + organization_posting.end_time)
+        - (organization_posting.start_date + organization_posting.start_time)
+      )) / 3600.0
+    )), 0)`.as('total_hours'))
+    .where('enrollment.volunteer_id', '=', volunteerId)
+    .where('enrollment_date.attended', '=', true)
+    .executeTakeFirstOrThrow();
 
-    const startMillis = combineDateTimeToDate(experience.start_date, experience.start_time).getTime();
-    const endMillis = combineDateTimeToDate(experience.end_date, experience.end_time).getTime();
-
-    if (Number.isNaN(startMillis) || Number.isNaN(endMillis) || endMillis <= startMillis) {
-      return totalHours;
-    }
-
-    return totalHours + ((endMillis - startMillis) / (1000 * 60 * 60));
-  }, 0);
-
-  const totalHoursCompleted = Math.round(totalHoursCompletedRaw * 10) / 10;
+  const totalHoursCompleted = Math.round((Number(totalHoursRow.total_hours ?? 0)) * 10) / 10;
 
   const crisisCountByName = new Map<string, number>();
   completedExperiences.forEach((experience) => {


### PR DESCRIPTION
What I did is:

-when a posting is one day, marking the volunteer as attended through the present button moves that posting to the previous experiences section, regardless of whether it's a full commitment or partial commitment posting
-when a postings is full commitment, pressing the button "present" should mark the volunteer as attended for all days and should move the posting to the previous experiences section
-for partial commitment postings, if the vol gets marked as attended for 1 day at least then that experience is moved to the previous experiences section

-Also made sure to change the related logic to hours counted in the certificate (specifically for partial attendance)

-updated the tests so that they have enrollment_date s